### PR TITLE
Revert app-colors to default and just change color on custom alert bar

### DIFF
--- a/custom/BHS/css/app-colors.css
+++ b/custom/BHS/css/app-colors.css
@@ -528,14 +528,14 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
   color: #c50f3c; }
   .prm-warn-bg, md-input-container.md-input-invalid:after, prm-tags-list .md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list .md-chips .md-input-invalid._md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid._md-chip-input-container:after {
     background-color: #c50f3c; }
-/*
+
 .prm-alert, .bar.alert-bar, .classic-input .search-scope {
   color: black; }
   .prm-alert-bg, .bar.alert-bar, .classic-input .search-scope {
     background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar, .classic-input .search-scope {
     border-color: #ede49e; }
-*/
+
 .prm-highlight {
   background-color: #FFFCC4; }
   .prm-highlight.prm-hue1, .list-item-wrapper .item-bookmarked,

--- a/custom/CENTRAL_PACKAGE/css/app-colors.css
+++ b/custom/CENTRAL_PACKAGE/css/app-colors.css
@@ -464,17 +464,9 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
 .prm-alert, .bar.alert-bar {
   color: black; }
   .prm-alert-bg, .bar.alert-bar {
-    background-color: #F89763; }
+    background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar {
-    border-color: #F89763; }
-  /*.prm-alert-border a, .bar.alert-bar a, .prm-alert-border [external-link], .bar.alert-bar [external-link] {*/
-  .bar.alert-bar {
-    font-size: 18px;
-    font-weight: 700;
-  }
-  .bar.alert-bar a, .bar.alert-bar [external-link] {
-    color: black;
-  }
+    border-color: #ede49e; }
 
 .prm-highlight {
   background-color: #FFFCC4; }

--- a/custom/CENTRAL_PACKAGE/css/sass/main.scss
+++ b/custom/CENTRAL_PACKAGE/css/sass/main.scss
@@ -15,3 +15,10 @@
 @import 'hide';
 
 @import '~primo-explore-custom-no-search-results/css/custom1.css';
+
+primo-explore-top-alert .bar.alert-bar {
+  font-size: 18px;
+  font-weight: 700;
+  border-color: #F89763;
+  background-color: #F89763 !important;
+}

--- a/custom/CU/css/app-colors.css
+++ b/custom/CU/css/app-colors.css
@@ -528,14 +528,14 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
   color: #c50f3c; }
   .prm-warn-bg, md-input-container.md-input-invalid:after, prm-tags-list .md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list .md-chips .md-input-invalid._md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid._md-chip-input-container:after {
     background-color: #c50f3c; }
-/*
+
 .prm-alert, .bar.alert-bar, .classic-input .search-scope {
   color: black; }
   .prm-alert-bg, .bar.alert-bar, .classic-input .search-scope {
     background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar, .classic-input .search-scope {
     border-color: #ede49e; }
-*/
+
 .prm-highlight {
   background-color: #FFFCC4; }
   .prm-highlight.prm-hue1, .list-item-wrapper .item-bookmarked,

--- a/custom/NYHS/css/app-colors.css
+++ b/custom/NYHS/css/app-colors.css
@@ -528,14 +528,14 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
   color: #c50f3c; }
   .prm-warn-bg, md-input-container.md-input-invalid:after, prm-tags-list .md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list .md-chips .md-input-invalid._md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid._md-chip-input-container:after {
     background-color: #c50f3c; }
-/*
+
 .prm-alert, .bar.alert-bar, .classic-input .search-scope {
   color: black; }
   .prm-alert-bg, .bar.alert-bar, .classic-input .search-scope {
     background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar, .classic-input .search-scope {
     border-color: #ede49e; }
-*/
+
 .prm-highlight {
   background-color: #FFFCC4; }
   .prm-highlight.prm-hue1, .list-item-wrapper .item-bookmarked,

--- a/custom/NYSID/css/app-colors.css
+++ b/custom/NYSID/css/app-colors.css
@@ -528,14 +528,14 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
   color: #c50f3c; }
   .prm-warn-bg, md-input-container.md-input-invalid:after, prm-tags-list .md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list .md-chips .md-input-invalid._md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid.md-chip-input-container:after, prm-tags-list md-chips .md-input-invalid._md-chip-input-container:after {
     background-color: #c50f3c; }
-/*
+
 .prm-alert, .bar.alert-bar, .classic-input .search-scope {
   color: black; }
   .prm-alert-bg, .bar.alert-bar, .classic-input .search-scope {
     background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar, .classic-input .search-scope {
     border-color: #ede49e; }
-*/
+
 .prm-highlight {
   background-color: #FFFCC4; }
   .prm-highlight.prm-hue1, .list-item-wrapper .item-bookmarked,

--- a/custom/NYU/css/app-colors.css
+++ b/custom/NYU/css/app-colors.css
@@ -460,14 +460,14 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
   color: #c50f3c; }
   .prm-warn-bg, md-input-container.md-input-invalid:after {
     background-color: #c50f3c; }
-/*
+
 .prm-alert, .bar.alert-bar {
   color: black; }
   .prm-alert-bg, .bar.alert-bar {
-    background-color: #F89763; }
+    background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar {
-    border-color: #F89763; }
-*/
+    border-color: #ede49e; }
+
 .prm-highlight {
   background-color: #FFFCC4; }
   .prm-highlight.prm-hue1, prm-brief-result-container.item-bookmarked, prm-brief-result-container.item-bookmarked:hover {

--- a/custom/NYUAD/css/app-colors.css
+++ b/custom/NYUAD/css/app-colors.css
@@ -460,14 +460,14 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
   color: #c50f3c; }
   .prm-warn-bg, md-input-container.md-input-invalid:after {
     background-color: #c50f3c; }
-/*
+
 .prm-alert, .bar.alert-bar {
   color: black; }
   .prm-alert-bg, .bar.alert-bar {
     background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar {
     border-color: #ede49e; }
-*/
+
 .prm-highlight {
   background-color: #FFFCC4; }
   .prm-highlight.prm-hue1, prm-brief-result-container.item-bookmarked, prm-brief-result-container.item-bookmarked:hover {

--- a/custom/NYUSH/css/app-colors.css
+++ b/custom/NYUSH/css/app-colors.css
@@ -460,14 +460,14 @@ md-toolbar.default-toolbar:not(.md-menu-toolbar) {
   color: #c50f3c; }
   .prm-warn-bg, md-input-container.md-input-invalid:after {
     background-color: #c50f3c; }
-/*
+
 .prm-alert, .bar.alert-bar {
   color: black; }
   .prm-alert-bg, .bar.alert-bar {
     background-color: #F7EDA3; }
   .prm-alert-border, .bar.alert-bar {
     border-color: #ede49e; }
-*/
+
 .prm-highlight {
   background-color: #FFFCC4; }
   .prm-highlight.prm-hue1, prm-brief-result-container.item-bookmarked, prm-brief-result-container.item-bookmarked:hover {


### PR DESCRIPTION
Reverting `app-colors.css` default colors and making the banner change at a global level referencing just the custom component