### PR TITLE
Change hide logic to remove default request options from the dom inst…

### DIFF
--- a/custom/common/js/customRequestComponent.js
+++ b/custom/common/js/customRequestComponent.js
@@ -11,15 +11,7 @@
     const ctrl = this;
 
     ctrl.$onInit = () => {
-      // Hide default request options if there are online links
-      const onlineLinks = angular.element($window.document).queryAll('#getit_link1_0 prm-view-online a');
-      const requestOptions = angular.element($window.document).queryAll('prm-location-items .md-list-item-text');
-
-      if (onlineLinks.length > 0) {
-        Array.from(requestOptions).forEach((requestOption) => {
-          requestOption.children().eq(2).css({ display: 'none' });
-        });
-      }
+      hideDefaultRequestsWhenHasOnlineLinks();
     };
 
     ctrl.$postLink = () => {
@@ -30,11 +22,20 @@
 
     $scope.hideCustomRequests = () => {
       const onlineLinks = angular.element($window.document).queryAll('#getit_link1_0 prm-view-online a');
+      return (onlineLinks.length > 0);
+    };
+
+    const hideDefaultRequestsWhenHasOnlineLinks = () => {
+      const onlineLinks = angular.element($window.document).queryAll('#getit_link1_0 prm-view-online a');
+      const requestOptions = angular.element($window.document).queryAll('prm-location-items .md-list-item-text');
 
       if (onlineLinks.length > 0) {
-        return true;
-      } else {
-        return false;
+        Array.from(requestOptions).forEach((requestOption) => {
+          // We have to remove this from the DOM instead of hiding it, because hiding with CSS clashes
+          // with the primo-explore-custom-requests explicitly showing them
+          requestOption.children().eq(2).remove();
+          // requestOption.children().eq(2).css({ display: 'none' });
+        });
       }
     };
   }]


### PR DESCRIPTION
…ead of trying to hide it which clashes with the primo-explore-custom-requests