### PR TITLE
Fix/request button selector change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules/
 *.idea/
 *.wiki/

--- a/custom/CENTRAL_PACKAGE/css/sass/_custom_requests.scss
+++ b/custom/CENTRAL_PACKAGE/css/sass/_custom_requests.scss
@@ -42,7 +42,7 @@ button[class*="custom-request-"] {
   }
 }
 
-.custom-requests-hide-request  {
+.custom-requests-hide-request {
   prm-service-button > button[aria-label*="Request Physical Copy"] {
     display: none !important;
   }

--- a/primo-explore-e2e-cypress/cypress/fixtures/example.json
+++ b/primo-explore-e2e-cypress/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}


### PR DESCRIPTION
I previously merged this feature branch into `development` using a straight command line git merge instead of a PR.
I found some trivial but valid changes I could make and re-created the branch so that it could be merged via PR for tracking purposes and for workflow consistency.

monday.com ticket: [Bug fix: correct request link display for multivolume requests](https://nyu-lib.monday.com/boards/765008773/pulses/2315942850)

EDIT: it looks like some automatic process (of IDE and/or cypress runners) caused the removal of the newline from primo-explore-e2e-cypress/cypress/fixtures/example.json, which I then accidentally committed with the `.gitignore`.  Didn't see this until after the PR had been created.  It's a completely benign change so not going to bother to revert it (and whatever caused it to happen could just keep happening anyway).