### PR TITLE
Update digital library link for NYHS [+]

### DIFF
--- a/custom/NYHS/html/home_en_US.html
+++ b/custom/NYHS/html/home_en_US.html
@@ -47,7 +47,7 @@
           <li><a href="https://www.nyhistory.org/library" target="_blank" rel="noreferrer">Dining Menus</a></li>
           <li><a href="https://www.nyhistory.org/library" target="_blank" rel="noreferrer">Hotel Files</a></li>
           <li><a href="https://www.nyhistory.org/library" target="_blank" rel="noreferrer">Apartment Building Files</a></li>
-          <li><a href="https://www.nyhistory.org/library" target="_blank" rel="noreferrer">Digital Library</a></li>
+          <li><a href="https://digitalcollections.nyhistory.org/" target="_blank" rel="noreferrer">Shelby White & Leon Levy Digital Library</a></li>
           <li><a href="https://www.nyhistory.org/library" target="_blank" rel="noreferrer">Onsite Electronic Resources</a></li>
           <li><a href="http://www.nyhistory.org/library/reference-assistance" target="_blank">E-mail Reference Form</a></li>
           <li><a href="http://www.nyhistory.org/about/rights-reproductions" target="_blank">Rights and Reproductions</a></li>


### PR DESCRIPTION
Replaces #351 -- updated file source: https://github.com/NYULibraries/primo-explore-views/pull/351/commits/adbbc7c2baafba5a7e8e5b2895a51888294ba7a6.
