### PR TITLE
Clear YAML syntax/parsing error in .circleci/config.yml [2nd attempt]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,45 +60,37 @@ jobs:
           path: coverage
 
   run-e2e-BHS:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: BHS
-    <<: [ *run-e2e-steps ]
   run-e2e-CENTRAL_PACKAGE:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: CENTRAL_PACKAGE
-    <<: [ *run-e2e-steps ]
   run-e2e-CU:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: CU
-    <<: [ *run-e2e-steps ]
   run-e2e-NYHS:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: NYHS
-    <<: [ *run-e2e-steps ]
   run-e2e-NYSID:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: NYSID
-    <<: [ *run-e2e-steps ]
   run-e2e-NYU:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: NYU
-    <<: [ *run-e2e-steps ]
   run-e2e-NYUAD:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: NYUAD
-    <<: [ *run-e2e-steps ]
   run-e2e-NYUSH:
-    <<: *docker-defaults
+    <<: [ *docker-defaults, *run-e2e-steps ]
     environment:
       VIEW: NYUSH
-    <<: [ *run-e2e-steps ]
 
   create-view-packages:
     <<: *docker-defaults


### PR DESCRIPTION
Second attempt of _.circleci/config.yml_: clear "YAMLParseError: Map keys must be unique" errors for `circleci-scripts`, and for YAML parsing in general.

CircleCI and its `circleci config validate` command are lenient and don't error out when there is a unique map keys violation.
This correction is for the `circleci-scripts` work in progress, and currently it's scraping HEAD commits, so need to merge this into `master` before can determine whether it's a problem.  (If this doesn't work, set up a minimum reproducible case)